### PR TITLE
Fix Settings Form losing selected level state on reload

### DIFF
--- a/Forms/SettingsForm.Designer.cs
+++ b/Forms/SettingsForm.Designer.cs
@@ -123,7 +123,6 @@ namespace Deep.Forms
             this.Levels.Name = "Levels";
             this.Levels.Size = new System.Drawing.Size(121, 21);
             this.Levels.TabIndex = 0;
-            this.Levels.SelectedIndexChanged += new System.EventHandler(this.Levels_SelectedIndexChanged);
             // 
             // SettingsForm
             // 
@@ -133,6 +132,7 @@ namespace Deep.Forms
             this.Controls.Add(this.tabControl1);
             this.Name = "SettingsForm";
             this.Text = "SettingsForm";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.SettingsForm_Closed);
             this.Load += new System.EventHandler(this.SettingsForm_Load);
             this.tabControl1.ResumeLayout(false);
             this.tabPage1.ResumeLayout(false);

--- a/Forms/SettingsForm.cs
+++ b/Forms/SettingsForm.cs
@@ -36,14 +36,14 @@ namespace Deep.Forms
 
         }
 
+        private void SettingsForm_Closed(object sender, FormClosedEventArgs e) {
+            Levels.SelectedIndexChanged -= changelevel;
+            solostop.CheckedChanged -= solostop_CheckStateChanged;
+        }
+
         private void changelevel(object sender, EventArgs e)
         {
             Logger.Verbose($"Changing the selected floor to run");
-            Settings.Instance.SelectedLevel = (FloorSetting)Levels.SelectedItem;
-        }
-
-        private void Levels_SelectedIndexChanged(object sender, EventArgs e)
-        {
             Settings.Instance.SelectedLevel = (FloorSetting)Levels.SelectedItem;
         }
 
@@ -52,6 +52,5 @@ namespace Deep.Forms
             Logger.Verbose($"Changing stop state");
             Settings.Instance.SoloStop = !Settings.Instance.SoloStop;
         }
-
     }
 }

--- a/Forms/SettingsForm.cs
+++ b/Forms/SettingsForm.cs
@@ -36,7 +36,8 @@ namespace Deep.Forms
 
         }
 
-        private void SettingsForm_Closed(object sender, FormClosedEventArgs e) {
+        private void SettingsForm_Closed(object sender, FormClosedEventArgs e) 
+        {
             Levels.SelectedIndexChanged -= changelevel;
             solostop.CheckedChanged -= solostop_CheckStateChanged;
         }


### PR DESCRIPTION
Currently, there are two issues that cause the selected level to be "reset" every time the settings form is loaded.

1: There are two event handlers for selected level changed. One created through the form designer (`Levels_SelectedIndexChanged`), and another one manually created (`changelevel`).
2: `changelevel` is added as a listener for selected level changes, but never removed, resulting in multiple events being fired on subsequent form loads

When the form is loaded, and `Levels.DataSource = Settings.Instance.FloorSettings;` is called, the event handlers that should not be triggered reset the value to the default one, as no value has been assigned yet, but the event handler tries to save the current value.

This PR fixes the issue.
